### PR TITLE
Clusters contain their child features

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,10 +11,11 @@ export interface Dimensions {
   height: number
 }
 
-export interface Cluster {
+export interface Cluster<Properties = any> {
   cluster: true;
   cluster_id: number;
   point_count: number;
+  features: Array<Properties>
 }
 
 export type ClusteredFeature<T> =

--- a/superclusterd.js
+++ b/superclusterd.js
@@ -103,7 +103,16 @@ class Index {
         return;
       }
 
-      const index = new Supercluster();
+      const index = new Supercluster({
+        map: (props) => {
+          return {
+            features: [props]
+          }
+        },
+        reduce: (accumulated, props) => {
+          accumulated.features = [...accumulated.features, ...props.features]
+        },
+      });
       const { features } = await res.json();
 
       this.lastFetch = Date.now();


### PR DESCRIPTION
Add child feature properties to a cluster's definition.

## Description

Adds `features` to the cluster `properties`, with whatever property data was inside the original features. This commit mainly leverages `SuperCluster`'s map/reduce options: https://www.npmjs.com/package/supercluster#user-content-property-mapreduce-options

## Motivation and Context

We used this in the Smart Forests project to display a hover-over list of items inside a cluster, for instance when multiple features are collocated down to the exact coordinates, so they will never be seen separately. It wasn't clear how to use the `cluster_id` to get leaf/child nodes natively through SuperCluster, via HTTP, so this seemed like the next easiest thing to do.

Example API response: https://superclusterd-uer9n.ondigitalocean.app/cluster/atlas.smartforests.net%2Fapi%2Fv2%2Fgeo%2F%3Flanguage_code%3Den?bbox=[-43.9971,-54.7275,142.7629,72.7929]&zoom=2

## How Can It Be Tested?

No tests

## How Will This Be Deployed?

No deployment changes required

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I've updated the documentation accordingly.
- [ ] Replace unused checkboxes with bullet points.